### PR TITLE
container pull: use modern options

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -6,8 +6,8 @@
   docker_image:
     name: "{{ zabbix.server.container_image }}"
     tag: "{{ zabbix.server.container_image_tag | default(omit) }}"
-    pull: yes
-    force: yes
+    source: pull
+    force_source: yes
   when: zabbix is defined
 
 - name: Setup zabbix server container


### PR DESCRIPTION
The existing options fail on newer ansible versions.